### PR TITLE
Add `msca.collections.UniqueSeq` class

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
     - id: trailing-whitespace
     - id: end-of-file-fixer
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v1.10.0
+  rev: v1.15.0
   hooks:
     - id: mypy
       files: ^src

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ classifiers = [
 dependencies = [
     "numpy",
     "scipy",
+    "pydantic",
 ]
 
 [project.optional-dependencies]

--- a/src/msca/collections/__init__.py
+++ b/src/msca/collections/__init__.py
@@ -1,0 +1,1 @@
+from .unique_seq import UniqueSeq

--- a/src/msca/collections/__init__.py
+++ b/src/msca/collections/__init__.py
@@ -1,1 +1,3 @@
 from .unique_seq import UniqueSeq
+
+__all__ = ["UniqueSeq"]

--- a/src/msca/collections/unique_seq.py
+++ b/src/msca/collections/unique_seq.py
@@ -1,0 +1,129 @@
+from itertools import chain, filterfalse
+from types import GenericAlias, UnionType
+from typing import (
+    Any,
+    Generator,
+    Hashable,
+    Iterable,
+    NoReturn,
+    Self,
+    Type,
+    TypeVar,
+    get_args,
+)
+
+from pydantic import GetCoreSchemaHandler
+from pydantic_core import core_schema
+
+T = TypeVar("T", bound=Hashable)
+
+
+def unique_everseen(iterable: Iterable[T], seen: Iterable[T] = ()) -> Generator:
+    seen = set(seen)
+    for item in filterfalse(seen.__contains__, iterable):
+        seen.add(item)
+        yield item
+
+
+def _unsupported_operand_type_error(operand: str, x: Any, y: Any) -> TypeError:
+    return TypeError(
+        "unsupported operand type(s) for {}: '{}' and '{}'".format(
+            operand, type(x).__name__, type(y).__name__
+        )
+    )
+
+
+def _wrong_number_of_arguments_error(
+    cls: Type, wrong_item_type: Any
+) -> TypeError:
+    return TypeError(
+        f"Wrong number of arguments for '{cls.__name__}', expected single item type, got '{wrong_item_type}'"
+    )
+
+
+def _unidentified_item_type_error(
+    item_type: Any, expected_item_types: tuple[Type, ...]
+) -> TypeError:
+    type_names = ", ".join(
+        [f"'{t.__module__}.{t.__name__}'" for t in expected_item_types]
+    )
+    return TypeError(
+        f"Unrecognized item type '{item_type}', expected an instance of the following types: {type_names}"
+    )
+
+
+def _extract_types_from_item_type(
+    item_type: Type | GenericAlias | UnionType, types: set[Type] | None = None
+) -> list[Type]:
+    types = set() if types is None else types
+    if isinstance(item_type, Type):
+        types.add(item_type)
+        return types
+    if isinstance(item_type, GenericAlias):
+        types.add(item_type.__origin__)
+    for item_sub_type in get_args(item_type):
+        _extract_types_from_item_type(item_sub_type, types=types)
+    return types
+
+
+class UniqueSeq(tuple[T, ...]):
+    def __new__(cls, iterable: Iterable[T] = ()) -> Self:
+        if isinstance(iterable, cls):
+            return iterable
+        return super().__new__(cls, unique_everseen(iterable))
+
+    def union(self, *iterables: Iterable[T]) -> Self:
+        value = unique_everseen(chain(*iterables), seen=self)
+        return super().__new__(type(self), chain(self, value))
+
+    def __or__(self, value: Iterable[T]) -> Self:
+        return self.union(value)
+
+    def __add__(self, value: Any) -> NoReturn:
+        raise _unsupported_operand_type_error("+", self, value)
+
+    def __mul__(self, value: Any) -> NoReturn:
+        raise _unsupported_operand_type_error("*", self, value)
+
+    def __rmul__(self, value: Any) -> NoReturn:
+        raise _unsupported_operand_type_error("*", value, self)
+
+    def __repr__(self) -> str:
+        return f"{type(self).__name__}({super().__repr__()})"
+
+    def __class_getitem__(
+        cls, item_type: Type | tuple[Type, ...]
+    ) -> GenericAlias:
+        if isinstance(item_type, tuple):
+            if len(item_type) != 1:
+                raise _wrong_number_of_arguments_error(cls, item_type)
+            item_type = item_type[0]
+
+        if item_type is not None:
+            expected_item_types = (Type, GenericAlias, UnionType)
+            if not isinstance(item_type, expected_item_types):
+                raise _unidentified_item_type_error(
+                    item_type, expected_item_types
+                )
+            bound = T.__bound__
+            extracted_types = _extract_types_from_item_type(item_type)
+            if not all(issubclass(t, bound) for t in extracted_types):
+                raise TypeError(
+                    f"Item type '{item_type}' is not a subclass of '{str(bound)}'"
+                )
+        return super().__class_getitem__(item_type)
+
+    @classmethod
+    def __get_pydantic_core_schema__(
+        cls, source: Any, handler: GetCoreSchemaHandler
+    ) -> core_schema.CoreSchema:
+        instance_schema = core_schema.is_instance_schema(cls)
+
+        item_type = get_args(source)
+        iterable_t_schema = handler.generate_schema(
+            Iterable[item_type] if len(item_type) > 0 else Iterable
+        )
+        non_instance_schema = core_schema.no_info_after_validator_function(
+            cls, iterable_t_schema
+        )
+        return core_schema.union_schema([instance_schema, non_instance_schema])

--- a/src/msca/collections/unique_seq.py
+++ b/src/msca/collections/unique_seq.py
@@ -119,10 +119,8 @@ class UniqueSeq(tuple[T, ...]):
     ) -> core_schema.CoreSchema:
         instance_schema = core_schema.is_instance_schema(cls)
 
-        item_type = get_args(source)
-        iterable_t_schema = handler.generate_schema(
-            Iterable[item_type] if len(item_type) > 0 else Iterable
-        )
+        item_type = get_args(source) or T.__bound__
+        iterable_t_schema = handler.generate_schema(Iterable[item_type])
         non_instance_schema = core_schema.no_info_after_validator_function(
             cls, iterable_t_schema
         )

--- a/tests/collections/test_unique_seq.py
+++ b/tests/collections/test_unique_seq.py
@@ -1,0 +1,148 @@
+from typing import Iterable
+
+import pytest
+from pydantic import BaseModel
+
+from msca.collections import UniqueSeq
+
+
+# All instances of Iterable[Hashable] should be accepted
+@pytest.mark.parametrize(
+    "x", [[1, 2, 3], (1, 2, 3), iter(["a", "b", "c", "c"])]
+)
+def test_new_success(x: Iterable) -> None:
+    a = UniqueSeq(x)
+    assert len(a) == len(set(a))
+
+
+# 1 is not iterable
+# In [1, [1, 2, 3]], [1, 2, 3] is not hashable
+@pytest.mark.parametrize("x", [1, [1, [1, 2, 3]]])
+def test_new_failure(x) -> None:
+    with pytest.raises(TypeError):
+        _ = UniqueSeq(x)
+
+
+# We block the concate operation from tuple. Since UniqueSeq need to keep
+# uniqueness, if we implement concate operation with other iterable, we cannot
+# gauranttee the length of the result equal the the sum of the length of the two
+# iterables, and it can cause confusion and make the behavior unpredictable.
+def test_add_failure() -> None:
+    a = UniqueSeq([1, 2, 3])
+    # UniqueSeq.__add__
+    with pytest.raises(TypeError):
+        _ = a + [1]
+
+
+# Same reason with concate operation above, we block the mul operation.
+def test_mul_failure() -> None:
+    a = UniqueSeq([1, 2, 3])
+    # UniqueSeq.__mul__
+    with pytest.raises(TypeError):
+        _ = a * 2
+    # UniqueSeq.__rmul__
+    with pytest.raises(TypeError):
+        _ = 2 * a
+
+
+# To make up the lack of add and mul operation, we introduce the or operation.
+# This operation will have similar behavior with the set.__or__ operation, which
+# will keep the uniqueness of the results. However UniqueSeq.__or__ will keep
+# the order of the arguments, and it accepts any instanace of Iterable[Hashable]
+# as the right operand.
+@pytest.mark.parametrize("b", [[1, 2, 4], (1, 2, 4), iter([1, 2, 4])])
+def test_or(b) -> None:
+    a = UniqueSeq([1, 2, 3])
+    # UniqueSeq.__or__
+    c = a | b
+    assert isinstance(c, UniqueSeq)
+    assert c == (1, 2, 3, 4)
+
+
+# We intentionally don't implement the UniqueSeq.__ror__ operation. It is
+# aligned with the built-in collection behavior. For example
+# >>> a = {1, 2, 3}
+# >>> b = frozenset([1, 2, 4])
+# >>> type(a | b)
+# <class 'set'>
+# >>> type(b | a)
+# <class 'frozenset'>
+# The result and the behavior depend on the left operand.
+def test_or_failure() -> None:
+    a = UniqueSeq([1, 2, 3])
+    b = [1, 2, 4]
+    with pytest.raises(TypeError):
+        _ = b | a
+
+
+# We also implement the UniqueSeq.union method, in case we want to combine
+# multiple iterables.
+def test_union() -> None:
+    a = UniqueSeq([1, 2, 3])
+    c = a.union([1, 2, 4], (1, 2, 5), iter((1, 2, 6)))
+    assert isinstance(c, UniqueSeq)
+    assert c == (1, 2, 3, 4, 5, 6)
+
+
+# Other common sequence operations, these are inherited from the tuple class.
+# https://docs.python.org/3/library/stdtypes.html#common-sequence-operations
+def test_other_common_seq_operations() -> None:
+    s = UniqueSeq(range(10))
+    # x in s
+    assert 5 in s
+    # x not in s
+    assert 10 not in s
+    # s[i]
+    assert s[5] == 5
+    # s[i:j]
+    assert s[3:6] == (3, 4, 5)
+    # s[i:j:k]
+    assert s[2:8:2] == (2, 4, 6)
+    # len(s)
+    assert len(s) == 10
+    # min(s)
+    assert min(s) == 0
+    # max(s)
+    assert max(s) == 9
+    # s.index(x[, i[, j]])
+    assert s.index(5) == 5
+    # s.count(x)
+    assert s.count(5) == 1
+
+
+# repr of UniqueSeq
+def test_repr() -> None:
+    a = UniqueSeq([1, 2, 3])
+    assert repr(a) == "UniqueSeq((1, 2, 3))"
+
+
+# UniqueSeq contains a generic type parameter and support type hinting.
+# UniqueSeq can only accept one item type, similar to Iterable.
+def test_single_item_type() -> None:
+    with pytest.raises(TypeError):
+        UniqueSeq[int, str]
+
+
+# UniqueSeq item type can be None and instances of typing.Type,
+# types.GenericAlias and types.UnionType, as long as they are hashable.
+# None: UniqueSeq[None] can actually only have one instance UniqueSeq((None,))
+# int: is instance of typing.Type
+# tuple[int, str]: is instance of types.GenericAlias
+# int | str: is instance of types.UnionType
+# tuple[int, str] | None: is instance of types.UnionType
+@pytest.mark.parametrize(
+    "T", [None, int, tuple[int, str], int | str, tuple[int, str] | None]
+)
+def test_item_type_success(T) -> None:
+    UniqueSeq[T]
+
+
+# When item type is not hashable, it will raise TypeError
+# we will replace all 'int' in the above example by list which will lead to the
+# failure of the type hinting.
+@pytest.mark.parametrize(
+    "T", [list, tuple[list, str], list | str, tuple[list, str] | None]
+)
+def test_item_type_failure(T) -> None:
+    with pytest.raises(TypeError):
+        UniqueSeq[T]

--- a/tests/collections/test_unique_seq.py
+++ b/tests/collections/test_unique_seq.py
@@ -135,17 +135,6 @@ def test_item_type_success(T) -> None:
     UniqueSeq[T]
 
 
-# When item type is not hashable, it will raise TypeError
-# we will replace all 'int' in the above example by list which will lead to the
-# failure of the type hinting.
-@pytest.mark.parametrize(
-    "T", [list, tuple[list, str], list | str, tuple[list, str] | None]
-)
-def test_item_type_failure(T) -> None:
-    with pytest.raises(TypeError):
-        UniqueSeq[T]
-
-
 # UniqueSeq is also compatible with pydantic Models
 # pydantic.BaseModel will automatically parse the input
 @pytest.mark.parametrize(
@@ -181,7 +170,7 @@ def test_pydantic_base_model_no_item_type() -> None:
     assert model.a == (1, 2, 3)
 
     # list [1, 2] is not hashable
-    with pytest.raises(ValidationError):
+    with pytest.raises(TypeError):
         _ = TestModel(a=[[1, 2]])
 
     # One exception for this is that if we provide tuple[int, ...] as the item


### PR DESCRIPTION
## Description

Add the `UniqueSeq` class, reference the conversation at
https://github.com/ihmeuw-msca/OneMod/pull/125

Majority of the documentation is at
`tests/collections/test_unique_seq.py`

@blsmxiu47 @kels271828, sorry guys I cannot help myself and really want to document what we have in this PR and I think it is a really cool pattern :)

* We should NOT use this in the OneMod PR
* This is not urgent by any means, take a look only if you find it interesting, and please let me know if you have any suggestions and ideas
* Later on, when this pattern emerges more frequently we can potentially use this as one of the options

Happy new year!