### PR TITLE
Explicitly specify `dtype` in pre-conditioner linear operator

### DIFF
--- a/src/msca/optim/precon/lbfgs.py
+++ b/src/msca/optim/precon/lbfgs.py
@@ -68,6 +68,8 @@ class LBFGSPreconBuilder:
                 z += (a_deque.pop() - b) * s
             return z
 
-        precon = LinearOperator((size, size), matvec=precon_mv)
+        precon = LinearOperator(
+            (size, size), matvec=precon_mv, dtype=x_pair[0].dtype
+        )
 
         return precon


### PR DESCRIPTION
## Description

@kels271828 reported a bug that the NewtonCG solver will fail with `lbfgs` pre-conditioner. The reported error is
```{bash}
File /mnt/team/msca/priv/jira/MSCA-399-rover-stage/env/lib/python3.12/site-packages/msca/optim/precon/lbfgs.py:63, in LBFGSPreconBuilder.__call__.<locals>.precon_mv(x)
     61 for s, y, r in reversed(iterator):
     62     a = r * s.dot(q)
---> 63     q -= a * y
     64     a_deque.append(a)
     65 z = gamma * q

UFuncTypeError: Cannot cast ufunc 'subtract' output from dtype('float64') to dtype('int8') with casting rule 'same_kind'
```
This error is due to not explicitly specify `dtype` in the [`scipy.sparse.linalg.LinearOperator`](https://docs.scipy.org/doc/scipy/reference/generated/scipy.sparse.linalg.LinearOperator.html). In the "Notes" section is says

> It is highly recommended to explicitly specify the dtype, otherwise it is determined automatically at the cost of a single matvec application on int8 zero vector using the promoted dtype of the output. Python int could be difficult to automatically cast to numpy integers in the definition of the [matvec](https://docs.scipy.org/doc/scipy/reference/generated/scipy.sparse.linalg.LinearOperator.matvec.html#scipy.sparse.linalg.LinearOperator.matvec) so the determination may be inaccurate. It is assumed that [matmat](https://docs.scipy.org/doc/scipy/reference/generated/scipy.sparse.linalg.LinearOperator.matmat.html#scipy.sparse.linalg.LinearOperator.matmat), [rmatvec](https://docs.scipy.org/doc/scipy/reference/generated/scipy.sparse.linalg.LinearOperator.rmatvec.html#scipy.sparse.linalg.LinearOperator.rmatvec), and [rmatmat](https://docs.scipy.org/doc/scipy/reference/generated/scipy.sparse.linalg.LinearOperator.rmatmat.html#scipy.sparse.linalg.LinearOperator.rmatmat) would result in the same dtype of the output given an int8 input as [matvec](https://docs.scipy.org/doc/scipy/reference/generated/scipy.sparse.linalg.LinearOperator.matvec.html#scipy.sparse.linalg.LinearOperator.matvec).


After specify the `dtype`, the error is gone :)