### PR TITLE
Fix linesearch

### DIFF
--- a/src/msca/optim/line_search/armijo.py
+++ b/src/msca/optim/line_search/armijo.py
@@ -3,54 +3,49 @@ from typing import Callable
 import numpy as np
 from numpy.typing import NDArray
 
-
 def armijo_line_search(
-    gradient: Callable,
-    x: NDArray,
-    dx: NDArray,
+    x,
+    p,
+    g,
+    objective: Callable,
     step_init: float = 1.0,
-    step_const: float = 0.01,
-    step_scale: float = 0.9,
-    step_lb: float = 1e-3,
-) -> float:
-    """Armijo line search.
-
-    Parameters
-    ----------
-    x
-        A list a parameters, including x, s, and v, where s is the slackness
-        variable and v is the dual variable for the constraints.
-    dx
-        A list of direction for the parameters.
-    step_init
-        Initial step size, by default 1.0.
-    step_const
-        Constant for the line search condition, the larger the harder, by
-        default 0.01.
-    step_scale
-        Shrinkage factor for step size, by default 0.9.
-    step_lb
-        Lower bound of the step size when the step size is below this bound
-        the line search will be terminated.
-
-    Returns
-    -------
-    float
-        The step size in the given direction.
-
+    alpha: float = 0.01,
+    shrinkage: float = 0.5,
+):
     """
+    Performs an Armijo line search to select an appropriate step size along a given search direction.
+    This function iteratively reduces the step size until the decrease in the objective function, along the direction of descent,
+    satisfies the Armijo (sufficient decrease) condition. In each iteration, it checks whether the new point yields a value that is
+    lower than the current value by a margin proportional to the step and directional derivative. If no satisfactory step size is found
+    and the step size becomes exceedingly small (<= 1e-15), a RuntimeError is raised.
+    Parameters:
+        x (array_like): The current point or position in the parameter space.
+        p (array_like): The descent direction along which the line search is performed.
+        g (array_like): The gradient of the objective function evaluated at x.
+        objective (Callable): A callable that computes the objective function value given a point.
+        step_init (float, optional): The initial step size to start the line search. Default is 1.0.
+        alpha (float, optional): The Armijo condition control parameter defining the sufficient decrease criterion. Default is 0.01.
+        shrinkage (float, optional): The factor by which the step is multiplied to reduce the step size in each iteration. Default is 0.5.
+    Returns:
+        float: The step size that satisfies the Armijo sufficient decrease condition.
+    Raises:
+        RuntimeError: If the step size becomes too small (<= 1e-15) without satisfying the Armijo condition,
+                      indicating failure in finding a suitable step size.
+    """
+    def sufficiently_improved(new_val, step):
+        return (new_val - val <= -1 * alpha * step * np.dot(g, p)) and (
+            not np.isnan(new_val)
+        )
+
     step = step_init
-    x_next = x + step * dx
-    g_next = gradient(x_next)
-    gnorm_curr = np.max(np.abs(gradient(x)))
-    gnorm_next = np.max(np.abs(g_next))
-
-    while gnorm_next > (1 - step_const * step) * gnorm_curr:
-        if step * step_scale < step_lb:
-            break
-        step *= step_scale
-        x_next = x + step * dx
-        g_next = gradient(x_next)
-        gnorm_next = np.max(np.abs(g_next))
-
+    new_x = x - step * p
+    val, new_val = objective(x), objective(new_x)
+    while (not sufficiently_improved(new_val, step)):
+        if step <= 1e-15:
+            raise RuntimeError(
+                f"Line Search Failed, new_val = {new_val}, prev_val = {val}"
+            )
+        step *= shrinkage
+        new_x = x - step * p
+        new_val = objective(new_x)
     return step

--- a/src/msca/optim/solver/ntcgsolver.py
+++ b/src/msca/optim/solver/ntcgsolver.py
@@ -126,7 +126,7 @@ class NTCGSolver:
             precon_builder = precon_builder_map[precon_builder](
                 **(precon_builder_options or {})
             )
-        cg_options = cg_options or {}
+        cg_options = cg_options or {"rtol":1e-2}
 
         def get_cg_maxiter(niter: int) -> int | None:
             if cg_maxiter_init is None and cg_maxiter is None:
@@ -168,7 +168,7 @@ class NTCGSolver:
             if precon_builder is not None:
                 cg_options["M"] = precon_builder(x_pair, g_pair)
             cg_options["maxiter"] = get_cg_maxiter(niter)
-            dx = cg(hess, -g, **cg_options)[0]
+            dx = cg(hess, -g,**cg_options)[0]
             try:
                 # get step size
                 step = line_search(x, -dx,g,self.fun, **line_search_options)

--- a/src/msca/optim/solver/ntcgsolver.py
+++ b/src/msca/optim/solver/ntcgsolver.py
@@ -169,9 +169,12 @@ class NTCGSolver:
                 cg_options["M"] = precon_builder(x_pair, g_pair)
             cg_options["maxiter"] = get_cg_maxiter(niter)
             dx = cg(hess, -g, **cg_options)[0]
-
-            # get step size
-            step = line_search(self.grad, x, dx, **line_search_options)
+            try:
+                # get step size
+                step = line_search(x, -dx,g,self.fun, **line_search_options)
+            except:
+                dx = -g
+                step = line_search(x, -dx,g,self.fun, **line_search_options)
             x = x + step * dx
 
             # update f and gnorm


### PR DESCRIPTION
Also update ntcg to fallback to a steepest descent step when cg step fails
Test on problem given by @kels271828 
New result:

```
NTCGSolver:
niter=  0, fun=1.77e+08, gnorm=1.48e+07, xdiff=1.00e+00, step=1.00e+00
niter=  1, fun=3.25e+07, gnorm=3.53e+06, xdiff=2.00e+00, step=1.00e+00, cg_iter=18
niter=  2, fun=1.09e+07, gnorm=1.23e+06, xdiff=1.14e+00, step=1.00e+00, cg_iter=18
niter=  3, fun=3.90e+06, gnorm=4.46e+05, xdiff=1.04e+00, step=1.00e+00, cg_iter=18
niter=  4, fun=1.43e+06, gnorm=1.63e+05, xdiff=1.02e+00, step=1.00e+00, cg_iter=18
niter=  5, fun=5.40e+05, gnorm=5.97e+04, xdiff=1.01e+00, step=1.00e+00, cg_iter=18
niter=  6, fun=2.15e+05, gnorm=2.18e+04, xdiff=1.00e+00, step=1.00e+00, cg_iter=18
niter=  7, fun=9.80e+04, gnorm=7.89e+03, xdiff=1.00e+00, step=1.00e+00, cg_iter=18
niter=  8, fun=5.67e+04, gnorm=2.78e+03, xdiff=1.00e+00, step=1.00e+00, cg_iter=19
niter=  9, fun=4.33e+04, gnorm=9.34e+02, xdiff=1.00e+00, step=1.00e+00, cg_iter=28
niter= 10, fun=3.96e+04, gnorm=2.68e+02, xdiff=9.99e-01, step=1.00e+00, cg_iter=32
niter= 11, fun=3.89e+04, gnorm=4.93e+01, xdiff=9.98e-01, step=1.00e+00, cg_iter=40
niter= 12, fun=3.88e+04, gnorm=6.83e+00, xdiff=9.95e-01, step=1.00e+00, cg_iter=48
niter= 13, fun=3.88e+04, gnorm=2.08e+00, xdiff=9.85e-01, step=1.00e+00, cg_iter=50
niter= 14, fun=3.88e+04, gnorm=5.48e-01, xdiff=9.60e-01, step=1.00e+00, cg_iter=54
niter= 15, fun=3.88e+04, gnorm=1.30e-01, xdiff=8.88e-01, step=1.00e+00, cg_iter=58
niter= 16, fun=3.88e+04, gnorm=2.12e-02, xdiff=6.93e-01, step=1.00e+00, cg_iter=58
niter= 17, fun=3.88e+04, gnorm=1.99e-03, xdiff=3.26e-01, step=1.00e+00, cg_iter=61
[ERROR FROM CG HERE]
niter= 18, fun=3.88e+04, gnorm=1.91e-03, xdiff=1.99e-03, step=1.00e+00, cg_iter=4400
niter= 19, fun=3.88e+04, gnorm=2.37e-02, xdiff=1.19e-04, step=6.25e-02, cg_iter=4600
niter= 20, fun=3.88e+04, gnorm=3.23e-05, xdiff=4.69e-02, step=1.00e+00, cg_iter=63
niter= 21, fun=3.88e+04, gnorm=3.10e-05, xdiff=3.23e-05, step=1.00e+00, cg_iter=5000
niter= 22, fun=3.88e+04, gnorm=6.47e-03, xdiff=7.75e-06, step=2.50e-01, cg_iter=5000
niter= 23, fun=3.88e+04, gnorm=1.03e-08, xdiff=7.41e-04, step=1.00e+00, cg_iter=67
train: 1.1554795350331246e-05
test: 1.3354692414270336e-05
```

Old Result:
```
NTCGSolver:
niter=  0, fun=1.77e+08, gnorm=1.48e+07, xdiff=1.00e+00, step=1.00e+00
niter=  1, fun=3.25e+07, gnorm=3.53e+06, xdiff=2.00e+00, step=1.00e+00, cg_iter=18
niter=  2, fun=1.09e+07, gnorm=1.23e+06, xdiff=1.14e+00, step=1.00e+00, cg_iter=18
niter=  3, fun=3.90e+06, gnorm=4.46e+05, xdiff=1.04e+00, step=1.00e+00, cg_iter=18
niter=  4, fun=1.43e+06, gnorm=1.63e+05, xdiff=1.02e+00, step=1.00e+00, cg_iter=18
niter=  5, fun=5.40e+05, gnorm=5.97e+04, xdiff=1.01e+00, step=1.00e+00, cg_iter=18
niter=  6, fun=2.15e+05, gnorm=2.18e+04, xdiff=1.00e+00, step=1.00e+00, cg_iter=18
niter=  7, fun=9.80e+04, gnorm=7.89e+03, xdiff=1.00e+00, step=1.00e+00, cg_iter=18
niter=  8, fun=5.67e+04, gnorm=2.78e+03, xdiff=1.00e+00, step=1.00e+00, cg_iter=19
niter=  9, fun=4.33e+04, gnorm=9.34e+02, xdiff=1.00e+00, step=1.00e+00, cg_iter=28
niter= 10, fun=3.96e+04, gnorm=2.68e+02, xdiff=9.99e-01, step=1.00e+00, cg_iter=32
niter= 11, fun=3.89e+04, gnorm=4.93e+01, xdiff=9.98e-01, step=1.00e+00, cg_iter=40
niter= 12, fun=3.88e+04, gnorm=6.83e+00, xdiff=9.95e-01, step=1.00e+00, cg_iter=48
niter= 13, fun=3.88e+04, gnorm=2.08e+00, xdiff=9.85e-01, step=1.00e+00, cg_iter=50
niter= 14, fun=3.88e+04, gnorm=5.48e-01, xdiff=9.60e-01, step=1.00e+00, cg_iter=54
niter= 15, fun=3.88e+04, gnorm=1.30e-01, xdiff=8.88e-01, step=1.00e+00, cg_iter=58
niter= 16, fun=3.88e+04, gnorm=2.12e-02, xdiff=6.93e-01, step=1.00e+00, cg_iter=58
niter= 17, fun=3.88e+04, gnorm=1.99e-03, xdiff=3.26e-01, step=1.00e+00, cg_iter=61
[ERROR FROM CG HERE]
niter= 18, fun=nan, gnorm=nan, xdiff=nan, step=1.00e+00, cg_iter=4400
niter= 19, fun=nan, gnorm=nan, xdiff=nan, step=1.00e+00, cg_iter=4600
niter= 20, fun=nan, gnorm=nan, xdiff=nan, step=1.00e+00, cg_iter=4800
niter= 21, fun=nan, gnorm=nan, xdiff=nan, step=1.00e+00, cg_iter=5000
```

Notes:
1. Previous Armijo linesearch wasn't doing armijo, but was checking for gradient norm decrease. Also, wasn't safeguarding against NaNs, (doing `while(a<b): do stuff`, but if a is Nan, then this will break from the while loop)
2. This problem is tiny, has 38 variables, we could really use a direct solver, I noticed this in other problems as well (test problem I'd run on before only has 1000
3. We can be more conservative with cg steps for this problem. It converges without the change to the linesearch if we limit to 500 cg steps (which should also be suspicious for numerical roundoff since there are only 38 variables!). We should really default to a cg maxiter scaled to the number of variables
4. If we scale to number of variables, it'd probably be good to include Nystrom preconditioner in the cg by default, even rank 10-50 seems like it can greatly improve numerical stability
5. Given the GLM structure of the objective, it may be worthwhile to rewrite the newton step as a reweighted least squares problem and apply LS(Q/M)R to it. 