### PR TITLE
Metric.eval when `data` is empty, fail clearly without a `groupby` and return empty dataframe otherwise

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "msca"
-version = "0.4.1"
+version = "0.4.2"
 description = "Mathematical sciences and computational algorithms"
 readme = "README.md"
 requires-python = ">=3.11,<3.13"

--- a/src/msca/metrics/main.py
+++ b/src/msca/metrics/main.py
@@ -244,23 +244,23 @@ class Metric(StrEnum):
         pd.DataFrame
             DataFrame with groupby columns and calculated metric/skill column
         """
-
         if data.empty:
-            grouped_results = pd.DataFrame(
-                columns=groupby + [self._get_metric_column_name(pred)]
+            raise ValueError(
+                "Input dataframe is empty, at least one row is required "
+                "to calculate metrics by group."
             )
-        else:
-            df = data.copy()
-            grouped_results = (
-                df.groupby(groupby)
-                .apply(
-                    self._eval_single,
-                    obs,
-                    pred,
-                    weights,
-                )
-                .reset_index()
+
+        df = data.copy()
+        grouped_results = (
+            df.groupby(groupby)
+            .apply(
+                self._eval_single,
+                obs,
+                pred,
+                weights,
             )
+            .reset_index()
+        )
 
         return grouped_results
 

--- a/src/msca/metrics/main.py
+++ b/src/msca/metrics/main.py
@@ -113,9 +113,9 @@ class Metric(StrEnum):
                 groupby=groupby,
             )
 
-            ref_score_col = f"{pred_ref}_{self.value}"
-            alt_score_col = f"{pred_alt}_{self.value}"
-            result_column_name = f"{pred_alt}_{self.value}_skill"
+            ref_score_col = self._get_metric_column_name(pred_ref)
+            alt_score_col = self._get_metric_column_name(pred_alt)
+            result_column_name = f"{alt_score_col}_skill"
 
             if (ref_scores[ref_score_col] == 0).any():
                 zero_ref_groups = ref_scores[ref_scores[ref_score_col] == 0][
@@ -166,11 +166,17 @@ class Metric(StrEnum):
         pd.Series
             Series with named metric value: f"{pred}_{self.value}"
         """
+        if data.empty:
+            raise ValueError(
+                "Input dataframe is empty, at least one row is required "
+                "to calculate single metrics."
+            )
+
         obs_values = data[obs].to_numpy()
         pred_values = data[pred].to_numpy()
         weight_values = data[weights].to_numpy()
 
-        column_name = f"{pred}_{self.value}"
+        column_name = self._get_metric_column_name(pred)
 
         match self:
             case Metric.ROOT_MEAN_SQUARED_ERROR:
@@ -238,16 +244,39 @@ class Metric(StrEnum):
         pd.DataFrame
             DataFrame with groupby columns and calculated metric/skill column
         """
-        df = data.copy()
-        grouped_results = (
-            df.groupby(groupby)
-            .apply(
-                self._eval_single,
-                obs,
-                pred,
-                weights,
+
+        if data.empty:
+            grouped_results = pd.DataFrame(
+                columns=groupby + [self._get_metric_column_name(pred)]
             )
-            .reset_index()
-        )
+        else:
+            df = data.copy()
+            grouped_results = (
+                df.groupby(groupby)
+                .apply(
+                    self._eval_single,
+                    obs,
+                    pred,
+                    weights,
+                )
+                .reset_index()
+            )
 
         return grouped_results
+
+    def _get_metric_column_name(self, pred: str) -> str:
+        """
+        Template the metric column name from the predicted values
+        column name and the Metric's string representation.
+
+        Parameters
+        ----------
+        pred : str
+            Predicted values column name
+
+        Returns
+        -------
+        str
+            Name of the metric value column, formatted as "{pred}_{self.value}"
+        """
+        return f"{pred}_{self.value}"

--- a/tests/metrics/test_metrics.py
+++ b/tests/metrics/test_metrics.py
@@ -1,7 +1,5 @@
-import numpy as np
 import pandas as pd
 import pytest
-from sklearn import metrics
 
 from msca.metrics import Metric  # Replace with actual import path
 
@@ -50,6 +48,27 @@ def test_eval_grouped(metric_enum, sample_data):
     assert isinstance(result_df, pd.DataFrame)
     assert "region" in result_df.columns
     metric_col = f"pred_{metric_enum.value}"
+    assert metric_col in result_df.columns
+    assert len(result_df) == sample_data["region"].nunique()
+
+
+@pytest.mark.parametrize(
+    "groupby",
+    [
+        None,
+        ["region"],
+    ],
+)
+def test_rmse_eval_empty_data(groupby, sample_data):
+    """Test that eval runs when data is empty with or without groupby."""
+    metric = Metric.ROOT_MEAN_SQUARED_ERROR
+    sample_data_empty = sample_data[0:0]
+    result_df = metric.eval(
+        sample_data_empty, "obs", "pred", "weights", groupby=groupby
+    )
+    assert isinstance(result_df, pd.DataFrame)
+    assert "region" in result_df.columns
+    metric_col = f"pred_{metric.value}"
     assert metric_col in result_df.columns
     assert len(result_df) == sample_data["region"].nunique()
 

--- a/tests/metrics/test_metrics.py
+++ b/tests/metrics/test_metrics.py
@@ -52,26 +52,13 @@ def test_eval_grouped(metric_enum, sample_data):
     assert len(result_df) == sample_data["region"].nunique()
 
 
-def test_rmse_eval_single_empty_data_fail(sample_data):
+@pytest.mark.parametrize("groupby", [None, ["region"]])
+def test_rmse_eval_empty_data_fail(sample_data, groupby):
     """Test that eval raises a clear error when data is empty without groupby."""
     with pytest.raises(ValueError, match="dataframe is empty"):
         Metric.ROOT_MEAN_SQUARED_ERROR.eval(
-            sample_data[0:0], "obs", "pred", "weights"
+            sample_data[0:0], "obs", "pred", "weights", groupby=groupby
         )
-
-
-def test_rmse_eval_grouped_empty_data_success(sample_data):
-    """Test that eval runs when data is empty with groupby."""
-    metric = Metric.ROOT_MEAN_SQUARED_ERROR
-    sample_data_empty = sample_data[0:0]
-    result = metric.eval(
-        sample_data_empty, "obs", "pred", "weights", groupby=["region"]
-    )
-    assert isinstance(result, pd.DataFrame)
-    assert "region" in result.columns
-    metric_col = f"pred_{metric.value}"
-    assert metric_col in result.columns
-    assert result.empty
 
 
 def test_eval_skill_single(sample_data):

--- a/tests/metrics/test_metrics.py
+++ b/tests/metrics/test_metrics.py
@@ -52,25 +52,26 @@ def test_eval_grouped(metric_enum, sample_data):
     assert len(result_df) == sample_data["region"].nunique()
 
 
-@pytest.mark.parametrize(
-    "groupby",
-    [
-        None,
-        ["region"],
-    ],
-)
-def test_rmse_eval_empty_data(groupby, sample_data):
-    """Test that eval runs when data is empty with or without groupby."""
+def test_rmse_eval_single_empty_data_fail(sample_data):
+    """Test that eval raises a clear error when data is empty without groupby."""
+    with pytest.raises(ValueError, match="dataframe is empty"):
+        Metric.ROOT_MEAN_SQUARED_ERROR.eval(
+            sample_data[0:0], "obs", "pred", "weights"
+        )
+
+
+def test_rmse_eval_grouped_empty_data_success(sample_data):
+    """Test that eval runs when data is empty with groupby."""
     metric = Metric.ROOT_MEAN_SQUARED_ERROR
     sample_data_empty = sample_data[0:0]
-    result_df = metric.eval(
-        sample_data_empty, "obs", "pred", "weights", groupby=groupby
+    result = metric.eval(
+        sample_data_empty, "obs", "pred", "weights", groupby=["region"]
     )
-    assert isinstance(result_df, pd.DataFrame)
-    assert "region" in result_df.columns
+    assert isinstance(result, pd.DataFrame)
+    assert "region" in result.columns
     metric_col = f"pred_{metric.value}"
-    assert metric_col in result_df.columns
-    assert len(result_df) == sample_data["region"].nunique()
+    assert metric_col in result.columns
+    assert result.empty
 
 
 def test_eval_skill_single(sample_data):


### PR DESCRIPTION
Metric.eval currently fails if `data` passed is empty. This PR introduces a clearer error when calculating a single metric or skill, and returns an empty dataframe when calculating across groups.

**Current behavior:**
* If `groupby` is not None, this line https://github.com/ihmeuw-msca/msca/blob/858c452053089c6854be82e623d392c8cef74de6/src/msca/metrics/main.py#L250 fails from within pandas, with a variation of "ValueError: cannot insert <groupby>, already exists"
* If `groupby` is None, error from within sklearn is raised, "ValueError: Found array with 0 sample(s) (shape=(0,)) while a minimum of 1 is required."

**New behavior:**
* If `groupby` is not None, return empty dataframe with the same set of columns that would be present if `data` is non-empty
* If `groupby` is None, raise an error that single metrics can't be calculated from empty dataframes