### PR TITLE
MSCA-794 Effective Sample Size

### DIFF
--- a/docs/api_reference/msca.modeling.rst
+++ b/docs/api_reference/msca.modeling.rst
@@ -1,0 +1,10 @@
+msca.modeling
+=============
+
+msca.modeling.effective_sample_size
+-----------------------------------
+
+.. automodule:: msca.modeling.effective_sample_size
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "msca"
-version = "0.4.2"
+version = "0.5.0"
 description = "Mathematical sciences and computational algorithms"
 readme = "README.md"
 requires-python = ">=3.11,<3.13"

--- a/src/msca/modeling/__init__.py
+++ b/src/msca/modeling/__init__.py
@@ -1,0 +1,3 @@
+from .effective_sample_size import effective_sample_size
+
+__all__ = ["effective_sample_size"]

--- a/src/msca/modeling/effective_sample_size.py
+++ b/src/msca/modeling/effective_sample_size.py
@@ -104,10 +104,11 @@ def _validate_data(
     if not pd.api.types.is_bool_dtype(data[is_vr]):
         raise ValueError(f"{is_vr} must be in boolean type")
 
-    if data.loc[data[is_vr].to_numpy(), completeness].isna().any():
-        raise ValueError(f"{completeness} must not be missing for VR rows")
+    vr_mask = data[is_vr].to_numpy()
+    if not data.loc[vr_mask, completeness].between(0.0, 1.0).all():
+        raise ValueError(f"{completeness} must be in [0, 1] for VR rows")
 
-    for col in (cause_fraction, completeness, pct_garbage):
+    for col in (cause_fraction, pct_garbage):
         if not data[col].between(0.0, 1.0).all():
             raise ValueError(f"{col} must be in [0, 1]")
 

--- a/src/msca/modeling/effective_sample_size.py
+++ b/src/msca/modeling/effective_sample_size.py
@@ -15,7 +15,7 @@ def _vr_effective_sample_size(
     completeness: pd.Series,
     pct_garbage: pd.Series,
     logit_pct_garbage_sd: pd.Series,
-    envelope_ub: float,
+    all_cause_death_rate_ub: float,
 ) -> pd.Series:
     """Effective binomial sample size for vital registration rows.
 
@@ -38,7 +38,7 @@ def _vr_effective_sample_size(
         garbage codes.
     logit_pct_garbage_sd
         Standard deviation of ``pct_garbage`` on the logit scale.
-    envelope_ub
+    all_cause_death_rate_ub
         Upper bound of the all-cause death rate. See
         :func:`effective_sample_size`.
 
@@ -50,7 +50,7 @@ def _vr_effective_sample_size(
     """
     n = completeness * population
     a = all_cause_death_rate * (
-        envelope_ub - cause_fraction * all_cause_death_rate
+        all_cause_death_rate_ub - cause_fraction * all_cause_death_rate
     )
     b = cause_fraction * (
         all_cause_death_rate_sd**2
@@ -71,7 +71,7 @@ def _non_vr_effective_sample_size(
     envelope: pd.Series,
     pct_garbage: pd.Series,
     logit_pct_garbage_sd: pd.Series,
-    envelope_ub: float,
+    all_cause_death_rate_ub: float,
 ) -> pd.Series:
     """Effective binomial sample size for non-registration rows.
 
@@ -96,7 +96,7 @@ def _non_vr_effective_sample_size(
         garbage codes.
     logit_pct_garbage_sd
         Standard deviation of ``pct_garbage`` on the logit scale.
-    envelope_ub
+    all_cause_death_rate_ub
         Upper bound of the all-cause death rate. See
         :func:`effective_sample_size`.
 
@@ -115,13 +115,15 @@ def _non_vr_effective_sample_size(
     pop_nonvr = env_nonvr / all_cause_death_rate
     # All-cause variance on the effective population implied by the sample.
     var_ra_nonvr = (
-        all_cause_death_rate * (envelope_ub - all_cause_death_rate) / pop_nonvr
+        all_cause_death_rate
+        * (all_cause_death_rate_ub - all_cause_death_rate)
+        / pop_nonvr
         + (pop_nonvr - 1.0).clip(lower=0.0)
         / pop_nonvr
         * all_cause_death_rate_sd**2
     )
     v = var_ra_nonvr + all_cause_death_rate**2
-    a = (envelope_ub - cause_fraction) * v
+    a = (all_cause_death_rate_ub - cause_fraction) * v
     b = (
         (env_nonvr - 1.0).clip(lower=0.0)
         * cause_fraction
@@ -133,7 +135,7 @@ def _non_vr_effective_sample_size(
     numerator = (
         env_nonvr
         * all_cause_death_rate
-        * (envelope_ub - cause_fraction * all_cause_death_rate)
+        * (all_cause_death_rate_ub - cause_fraction * all_cause_death_rate)
     )
     denominator = a + b + c
     return numerator / denominator
@@ -150,7 +152,7 @@ def _validate_data(
     completeness: str,
     pct_garbage: str,
     logit_pct_garbage_mad: str,
-    envelope_ub: float,
+    all_cause_death_rate_ub: float,
 ) -> None:
     """Check the inputs of :func:`effective_sample_size`.
 
@@ -190,10 +192,11 @@ def _validate_data(
         if (data[col] <= 0).any():
             raise ValueError(f"{col} must be positive")
 
-    if (data[envelope] / data[population] > envelope_ub).any():
-        raise ValueError(
-            f"{envelope} / {population} must be less than or equal to envelope_ub ({envelope_ub})"
-        )
+    assert not (
+        data[envelope] / data[population] > all_cause_death_rate_ub
+    ).any(), (
+        f"{envelope} / {population} must be less than or equal to all_cause_death_rate_ub ({all_cause_death_rate_ub})"
+    )
 
 
 def effective_sample_size(
@@ -207,17 +210,17 @@ def effective_sample_size(
     completeness: str,
     pct_garbage: str,
     logit_pct_garbage_mad: str,
-    envelope_ub: float,
+    all_cause_death_rate_ub: float,
 ) -> pd.Series:
     """Effective binomial sample size of a cause-specific death rate.
 
-    The cause-specific death rate is treated as a binomial proportion on
-    ``[0, envelope_ub]``. The value returned for a row is the binomial
-    sample size whose sampling variance matches that row's total
-    variance, which combines uncertainty in the all-cause envelope with
-    uncertainty from garbage-code redistribution. It is intended for use
-    as an observation weight, and is always at most the row's nominal
-    sample size.
+    The cause-specific death rate is treated as a binomial proportion
+    on ``[0, all_cause_death_rate_ub]``. The value returned for a row is
+    the binomial sample size whose sampling variance matches that row's
+    total variance, which combines uncertainty in the all-cause envelope
+    with uncertainty from garbage-code redistribution. It is intended for
+    use as an observation weight, and is always at most the row's
+    nominal sample size.
 
     Registration and non-registration rows are computed differently:
     the former take their population at risk from the data, the latter
@@ -227,8 +230,8 @@ def effective_sample_size(
     Parameters
     ----------
     data
-        Observation rows. Every argument below other than ``envelope_ub``
-        names a column to read from it.
+        Observation rows. Every argument below other than
+        ``all_cause_death_rate_ub`` names a column to read from it.
     is_vr
         Column flagging vital registration rows. Must be a boolean
         dtype; 0/1 integer columns are rejected rather than coerced.
@@ -257,7 +260,7 @@ def effective_sample_size(
         Column of the median absolute deviation of ``pct_garbage`` on
         the logit scale. Converted to a standard deviation with the
         normal-consistency factor 1.4826.
-    envelope_ub
+    all_cause_death_rate_ub
         Upper bound of the all-cause death rate, on the same scale as
         ``envelope / population``, which must not exceed it.
 
@@ -273,9 +276,12 @@ def effective_sample_size(
     ValueError
         If a required column has missing values, ``is_vr`` is not a
         boolean dtype, a proportion falls outside ``[0, 1]``, a
-        quantity required to be positive is not, ``envelope /
-        population`` exceeds ``envelope_ub``, or a computed sample size
-        comes out non-finite or negative.
+        quantity required to be positive is not, or a computed sample
+        size comes out non-finite or negative.
+    AssertionError
+        If ``envelope / population`` exceeds
+        ``all_cause_death_rate_ub``. This check is an assertion, so it
+        is removed when Python is run with ``-O``.
 
     Notes
     -----
@@ -295,7 +301,7 @@ def effective_sample_size(
     ...     completeness="completeness",
     ...     pct_garbage="pct_garbage",
     ...     logit_pct_garbage_mad="variance_rd_logit_cf",
-    ...     envelope_ub=4.0,
+    ...     all_cause_death_rate_ub=4.0,
     ... )
 
     """
@@ -310,7 +316,7 @@ def effective_sample_size(
         completeness,
         pct_garbage,
         logit_pct_garbage_mad,
-        envelope_ub,
+        all_cause_death_rate_ub,
     )
 
     # Compute the all-cause death rate and convert SD from death-count to rate scale
@@ -329,7 +335,7 @@ def effective_sample_size(
         completeness=data.loc[vr_mask, completeness],
         pct_garbage=data.loc[vr_mask, pct_garbage],
         logit_pct_garbage_sd=logit_pct_garbage_sd[vr_mask],
-        envelope_ub=envelope_ub,
+        all_cause_death_rate_ub=all_cause_death_rate_ub,
     )
     weights[~vr_mask] = _non_vr_effective_sample_size(
         cause_fraction=data.loc[~vr_mask, cause_fraction],
@@ -339,7 +345,7 @@ def effective_sample_size(
         envelope=data.loc[~vr_mask, envelope],
         pct_garbage=data.loc[~vr_mask, pct_garbage],
         logit_pct_garbage_sd=logit_pct_garbage_sd[~vr_mask],
-        envelope_ub=envelope_ub,
+        all_cause_death_rate_ub=all_cause_death_rate_ub,
     )
 
     not_valid = ~np.isfinite(weights) | (weights < 0)

--- a/src/msca/modeling/effective_sample_size.py
+++ b/src/msca/modeling/effective_sample_size.py
@@ -3,9 +3,6 @@
 import numpy as np
 import pandas as pd
 
-# Normal-consistency factor from median absolute deviation to SD.
-_MAD_TO_SD = 1.4826
-
 
 def _vr_effective_sample_size(
     cause_fraction: pd.Series,
@@ -151,7 +148,7 @@ def _validate_data(
     envelope_sd: str,
     completeness: str,
     pct_garbage: str,
-    logit_pct_garbage_mad: str,
+    logit_pct_garbage_sd: str,
     all_cause_death_rate_ub: float,
 ) -> None:
     """Check the inputs of :func:`effective_sample_size`.
@@ -170,7 +167,7 @@ def _validate_data(
         envelope,
         envelope_sd,
         pct_garbage,
-        logit_pct_garbage_mad,
+        logit_pct_garbage_sd,
     ]
     na_cols = [col for col in nona_columns if data[col].isna().any()]
     if len(na_cols) > 0:
@@ -209,7 +206,7 @@ def effective_sample_size(
     envelope_sd: str,
     completeness: str,
     pct_garbage: str,
-    logit_pct_garbage_mad: str,
+    logit_pct_garbage_sd: str,
     all_cause_death_rate_ub: float,
 ) -> pd.Series:
     """Effective binomial sample size of a cause-specific death rate.
@@ -256,10 +253,11 @@ def effective_sample_size(
     pct_garbage
         Column of the fraction of the cause's deaths that came from
         redistributed garbage codes, in ``[0, 1]``.
-    logit_pct_garbage_mad
-        Column of the median absolute deviation of ``pct_garbage`` on
-        the logit scale. Converted to a standard deviation with the
-        normal-consistency factor 1.4826.
+    logit_pct_garbage_sd
+        Column of the standard deviation of ``pct_garbage`` on the logit
+        scale. If the source quantity is a median absolute deviation,
+        scale it by the normal-consistency factor 1.4826 before passing
+        it; this function no longer does that conversion.
     all_cause_death_rate_ub
         Upper bound of the all-cause death rate, on the same scale as
         ``envelope / population``, which must not exceed it.
@@ -300,7 +298,7 @@ def effective_sample_size(
     ...     envelope_sd="envelope_sd",
     ...     completeness="completeness",
     ...     pct_garbage="pct_garbage",
-    ...     logit_pct_garbage_mad="variance_rd_logit_cf",
+    ...     logit_pct_garbage_sd="logit_pct_garbage_sd",
     ...     all_cause_death_rate_ub=4.0,
     ... )
 
@@ -315,15 +313,13 @@ def effective_sample_size(
         envelope_sd,
         completeness,
         pct_garbage,
-        logit_pct_garbage_mad,
+        logit_pct_garbage_sd,
         all_cause_death_rate_ub,
     )
 
     # Compute the all-cause death rate and convert SD from death-count to rate scale
     all_cause_death_rate = data[envelope] / data[population]
     all_cause_death_rate_sd = data[envelope_sd] / data[population]
-    # Derive the redistribution SD from the logit-pct-garbage MAD (source is a MAD)
-    logit_pct_garbage_sd = _MAD_TO_SD * data[logit_pct_garbage_mad]
 
     weights = pd.Series(index=data.index, dtype="float64")
     vr_mask = data[is_vr].to_numpy()
@@ -334,7 +330,7 @@ def effective_sample_size(
         population=data.loc[vr_mask, population],
         completeness=data.loc[vr_mask, completeness],
         pct_garbage=data.loc[vr_mask, pct_garbage],
-        logit_pct_garbage_sd=logit_pct_garbage_sd[vr_mask],
+        logit_pct_garbage_sd=data.loc[vr_mask, logit_pct_garbage_sd],
         all_cause_death_rate_ub=all_cause_death_rate_ub,
     )
     weights[~vr_mask] = _non_vr_effective_sample_size(
@@ -344,7 +340,7 @@ def effective_sample_size(
         all_cause_death_rate_sd=all_cause_death_rate_sd[~vr_mask],
         envelope=data.loc[~vr_mask, envelope],
         pct_garbage=data.loc[~vr_mask, pct_garbage],
-        logit_pct_garbage_sd=logit_pct_garbage_sd[~vr_mask],
+        logit_pct_garbage_sd=data.loc[~vr_mask, logit_pct_garbage_sd],
         all_cause_death_rate_ub=all_cause_death_rate_ub,
     )
 

--- a/src/msca/modeling/effective_sample_size.py
+++ b/src/msca/modeling/effective_sample_size.py
@@ -7,97 +7,108 @@ _MAD_TO_SD = 1.4826
 
 
 def vr_effective_sample_size(
-    completeness: pd.Series,
-    population: pd.Series,
-    mx: pd.Series,
     cause_fraction: pd.Series,
-    mx_sd: pd.Series,
+    all_cause_death_rate: pd.Series,
+    all_cause_death_rate_sd: pd.Series,
+    population: pd.Series,
+    completeness: pd.Series,
     pct_garbage: pd.Series,
     logit_pct_garbage_sd: pd.Series,
     envelope_ub: float,
 ) -> pd.Series:
     """VR effective binomial sample size."""
     n = completeness * population
-    a = mx * (envelope_ub - cause_fraction * mx)
+    a = all_cause_death_rate * (
+        envelope_ub - cause_fraction * all_cause_death_rate
+    )
     b = cause_fraction * (
-        mx_sd**2 + pct_garbage**2 * logit_pct_garbage_sd**2 * (mx**2 + mx_sd**2)
+        all_cause_death_rate_sd**2
+        + pct_garbage**2
+        * logit_pct_garbage_sd**2
+        * (all_cause_death_rate**2 + all_cause_death_rate_sd**2)
     )
     numerator = n * a
     denominator = a + (n - 1.0).clip(lower=0.0) * b
     return numerator / denominator
 
 
-def va_effective_sample_size(
-    sample_size: pd.Series,
-    envelope: pd.Series,
-    mx: pd.Series,
+def nonvr_effective_sample_size(
     cause_fraction: pd.Series,
-    mx_sd: pd.Series,
+    sample_size: pd.Series,
+    all_cause_death_rate: pd.Series,
+    all_cause_death_rate_sd: pd.Series,
+    envelope: pd.Series,
     pct_garbage: pd.Series,
     logit_pct_garbage_sd: pd.Series,
     envelope_ub: float,
 ) -> pd.Series:
     """VA effective binomial sample size."""
     # A cause's VA count can't exceed the all-cause envelope; capping there also keeps the
-    # effective all-cause population env_va / mx <= n_pop, no separate population cap is needed.
-    env_va = sample_size.clip(upper=envelope)
-    pop_va = env_va / mx
+    # effective all-cause population env_nonvr / all_cause_death_rate <= n_pop, no separate population cap is needed.
+    env_nonvr = sample_size.clip(upper=envelope)
+    pop_nonvr = env_nonvr / all_cause_death_rate
     # All-cause variance on the effective population implied by the VA sample.
-    var_ra_va = (
-        mx * (envelope_ub - mx) / pop_va
-        + (pop_va - 1.0).clip(lower=0.0) / pop_va * mx_sd**2
+    var_ra_nonvr = (
+        all_cause_death_rate * (envelope_ub - all_cause_death_rate) / pop_nonvr
+        + (pop_nonvr - 1.0).clip(lower=0.0)
+        / pop_nonvr
+        * all_cause_death_rate_sd**2
     )
-    v = var_ra_va + mx**2
+    v = var_ra_nonvr + all_cause_death_rate**2
     a = (envelope_ub - cause_fraction) * v
     b = (
-        (env_va - 1.0).clip(lower=0.0)
+        (env_nonvr - 1.0).clip(lower=0.0)
         * cause_fraction
         * pct_garbage**2
         * logit_pct_garbage_sd**2
         * v
     )
-    c = env_va * cause_fraction * var_ra_va
-    numerator = env_va * mx * (envelope_ub - cause_fraction * mx)
+    c = env_nonvr * cause_fraction * var_ra_nonvr
+    numerator = (
+        env_nonvr
+        * all_cause_death_rate
+        * (envelope_ub - cause_fraction * all_cause_death_rate)
+    )
     denominator = a + b + c
     return numerator / denominator
 
 
 def effective_sample_size(
     is_vr: pd.Series,
-    completeness: pd.Series,
+    cause_fraction: pd.Series,
     sample_size: pd.Series,
     population: pd.Series,
     envelope: pd.Series,
     envelope_sd: pd.Series,
-    cause_fraction: pd.Series,
+    completeness: pd.Series,
     pct_garbage: pd.Series,
     logit_pct_garbage_mad: pd.Series,
     envelope_ub: float,
 ) -> pd.Series:
     """Per-row effective binomial sample size: VR where ``is_vr`` else VA."""
     # Compute the all-cause death rate and convert SD from death-count to rate scale
-    mx = envelope / population
-    mx_sd = envelope_sd / population
+    all_cause_death_rate = envelope / population
+    all_cause_death_rate_sd = envelope_sd / population
     # Derive the redistribution SD from the logit-pct-garbage MAD (source is a MAD)
     logit_pct_garbage_sd = _MAD_TO_SD * logit_pct_garbage_mad
 
     weights = pd.Series(index=is_vr.index, dtype="float64")
     weights[is_vr] = vr_effective_sample_size(
-        completeness=completeness[is_vr],
-        population=population[is_vr],
-        mx=mx[is_vr],
         cause_fraction=cause_fraction[is_vr],
-        mx_sd=mx_sd[is_vr],
+        all_cause_death_rate=all_cause_death_rate[is_vr],
+        all_cause_death_rate_sd=all_cause_death_rate_sd[is_vr],
+        population=population[is_vr],
+        completeness=completeness[is_vr],
         pct_garbage=pct_garbage[is_vr],
         logit_pct_garbage_sd=logit_pct_garbage_sd[is_vr],
         envelope_ub=envelope_ub,
     )
-    weights[~is_vr] = va_effective_sample_size(
-        sample_size=sample_size[~is_vr],
-        envelope=envelope[~is_vr],
-        mx=mx[~is_vr],
+    weights[~is_vr] = nonvr_effective_sample_size(
         cause_fraction=cause_fraction[~is_vr],
-        mx_sd=mx_sd[~is_vr],
+        sample_size=sample_size[~is_vr],
+        all_cause_death_rate=all_cause_death_rate[~is_vr],
+        all_cause_death_rate_sd=all_cause_death_rate_sd[~is_vr],
+        envelope=envelope[~is_vr],
         pct_garbage=pct_garbage[~is_vr],
         logit_pct_garbage_sd=logit_pct_garbage_sd[~is_vr],
         envelope_ub=envelope_ub,

--- a/src/msca/modeling/effective_sample_size.py
+++ b/src/msca/modeling/effective_sample_size.py
@@ -17,7 +17,37 @@ def _vr_effective_sample_size(
     logit_pct_garbage_sd: pd.Series,
     envelope_ub: float,
 ) -> pd.Series:
-    """VR effective binomial sample size."""
+    """Effective binomial sample size for vital registration rows.
+
+    Parameters
+    ----------
+    cause_fraction
+        Fraction of all-cause deaths assigned to the cause.
+    all_cause_death_rate
+        All-cause death rate, ``envelope / population``.
+    all_cause_death_rate_sd
+        Standard deviation of ``all_cause_death_rate``.
+    population
+        Population at risk.
+    completeness
+        Fraction of deaths captured by the registration system. The
+        registered death count ``completeness * population`` is the
+        upper limit that the variance terms shrink towards.
+    pct_garbage
+        Fraction of the cause's deaths that came from redistributed
+        garbage codes.
+    logit_pct_garbage_sd
+        Standard deviation of ``pct_garbage`` on the logit scale.
+    envelope_ub
+        Upper bound of the all-cause death rate. See
+        :func:`effective_sample_size`.
+
+    Returns
+    -------
+    Series
+        Effective binomial sample size for each row.
+
+    """
     n = completeness * population
     a = all_cause_death_rate * (
         envelope_ub - cause_fraction * all_cause_death_rate
@@ -43,12 +73,47 @@ def _non_vr_effective_sample_size(
     logit_pct_garbage_sd: pd.Series,
     envelope_ub: float,
 ) -> pd.Series:
-    """VA effective binomial sample size."""
-    # A cause's VA count can't exceed the all-cause envelope; capping there also keeps the
-    # effective all-cause population env_nonvr / all_cause_death_rate <= n_pop, no separate population cap is needed.
+    """Effective binomial sample size for non-registration rows.
+
+    Unlike the vital registration form, the population at risk is not
+    taken from the data. It is implied by the reported sample size,
+    which stands in for the source's all-cause death count.
+
+    Parameters
+    ----------
+    cause_fraction
+        Fraction of all-cause deaths assigned to the cause.
+    sample_size
+        Deaths reported by the source, capped at ``envelope``.
+    all_cause_death_rate
+        All-cause death rate, ``envelope / population``.
+    all_cause_death_rate_sd
+        Standard deviation of ``all_cause_death_rate``.
+    envelope
+        All-cause deaths, used to cap ``sample_size``.
+    pct_garbage
+        Fraction of the cause's deaths that came from redistributed
+        garbage codes.
+    logit_pct_garbage_sd
+        Standard deviation of ``pct_garbage`` on the logit scale.
+    envelope_ub
+        Upper bound of the all-cause death rate. See
+        :func:`effective_sample_size`.
+
+    Returns
+    -------
+    Series
+        Effective binomial sample size for each row.
+
+    """
+    # A cause's death count can't exceed the all-cause envelope. Capping
+    # there also bounds the implied all-cause population, because
+    # env_nonvr / all_cause_death_rate <= envelope / all_cause_death_rate,
+    # which is the population itself, so no separate population cap is
+    # needed.
     env_nonvr = sample_size.clip(upper=envelope)
     pop_nonvr = env_nonvr / all_cause_death_rate
-    # All-cause variance on the effective population implied by the VA sample.
+    # All-cause variance on the effective population implied by the sample.
     var_ra_nonvr = (
         all_cause_death_rate * (envelope_ub - all_cause_death_rate) / pop_nonvr
         + (pop_nonvr - 1.0).clip(lower=0.0)
@@ -87,6 +152,14 @@ def _validate_data(
     logit_pct_garbage_mad: str,
     envelope_ub: float,
 ) -> None:
+    """Check the inputs of :func:`effective_sample_size`.
+
+    Raises
+    ------
+    ValueError
+        If any input is missing, of the wrong dtype, or out of range.
+
+    """
     nona_columns = [
         is_vr,
         cause_fraction,
@@ -104,6 +177,7 @@ def _validate_data(
     if not pd.api.types.is_bool_dtype(data[is_vr]):
         raise ValueError(f"{is_vr} must be in boolean type")
 
+    # completeness only feeds the VR form, so it is unconstrained elsewhere
     vr_mask = data[is_vr].to_numpy()
     if not data.loc[vr_mask, completeness].between(0.0, 1.0).all():
         raise ValueError(f"{completeness} must be in [0, 1] for VR rows")
@@ -135,7 +209,96 @@ def effective_sample_size(
     logit_pct_garbage_mad: str,
     envelope_ub: float,
 ) -> pd.Series:
-    """Per-row effective binomial sample size: VR where ``is_vr`` else VA."""
+    """Effective binomial sample size of a cause-specific death rate.
+
+    The cause-specific death rate is treated as a binomial proportion on
+    ``[0, envelope_ub]``. The value returned for a row is the binomial
+    sample size whose sampling variance matches that row's total
+    variance, which combines uncertainty in the all-cause envelope with
+    uncertainty from garbage-code redistribution. It is intended for use
+    as an observation weight, and is always at most the row's nominal
+    sample size.
+
+    Registration and non-registration rows are computed differently:
+    the former take their population at risk from the data, the latter
+    infer it from the reported sample size. ``is_vr`` selects between
+    them.
+
+    Parameters
+    ----------
+    data
+        Observation rows. Every argument below other than ``envelope_ub``
+        names a column to read from it.
+    is_vr
+        Column flagging vital registration rows. Must be a boolean
+        dtype; 0/1 integer columns are rejected rather than coerced.
+    cause_fraction
+        Column of the fraction of all-cause deaths assigned to the
+        cause, in ``[0, 1]``.
+    sample_size
+        Column of deaths reported by the source. Only the non-VR form
+        reads it, where it is capped at ``envelope``, but it must be
+        present and positive on every row.
+    population
+        Column of population at risk. Must be positive.
+    envelope
+        Column of all-cause deaths. Must be positive.
+    envelope_sd
+        Column of the standard deviation of ``envelope``. Must be
+        positive.
+    completeness
+        Column of the fraction of deaths captured by the registration
+        system, in ``[0, 1]``. Only the VR form reads it, and it is only
+        validated on VR rows, so it may be missing on the others.
+    pct_garbage
+        Column of the fraction of the cause's deaths that came from
+        redistributed garbage codes, in ``[0, 1]``.
+    logit_pct_garbage_mad
+        Column of the median absolute deviation of ``pct_garbage`` on
+        the logit scale. Converted to a standard deviation with the
+        normal-consistency factor 1.4826.
+    envelope_ub
+        Upper bound of the all-cause death rate, on the same scale as
+        ``envelope / population``, which must not exceed it.
+
+    Returns
+    -------
+    Series
+        Effective binomial sample size for each row of ``data``, sharing
+        its index. Zero is a valid result and means the row carries no
+        information, as happens when ``completeness`` is zero.
+
+    Raises
+    ------
+    ValueError
+        If a required column has missing values, ``is_vr`` is not a
+        boolean dtype, a proportion falls outside ``[0, 1]``, a
+        quantity required to be positive is not, ``envelope /
+        population`` exceeds ``envelope_ub``, or a computed sample size
+        comes out non-finite or negative.
+
+    Notes
+    -----
+    ``envelope`` and ``envelope_sd`` are given on the death-count scale
+    and are converted to rates here by dividing by ``population``.
+
+    Examples
+    --------
+    >>> weights = effective_sample_size(
+    ...     data,
+    ...     is_vr="is_vr",
+    ...     cause_fraction="cause_fraction",
+    ...     sample_size="sample_size",
+    ...     population="population",
+    ...     envelope="envelope",
+    ...     envelope_sd="envelope_sd",
+    ...     completeness="completeness",
+    ...     pct_garbage="pct_garbage",
+    ...     logit_pct_garbage_mad="variance_rd_logit_cf",
+    ...     envelope_ub=4.0,
+    ... )
+
+    """
     _validate_data(
         data,
         is_vr,

--- a/src/msca/modeling/effective_sample_size.py
+++ b/src/msca/modeling/effective_sample_size.py
@@ -1,0 +1,105 @@
+"""Effective binomial sample size of a cause-specific death rate."""
+
+import pandas as pd
+
+# Normal-consistency factor from median absolute deviation to SD.
+_MAD_TO_SD = 1.4826
+
+
+def vr_effective_sample_size(
+    completeness: pd.Series,
+    population: pd.Series,
+    mx: pd.Series,
+    cause_fraction: pd.Series,
+    mx_sd: pd.Series,
+    pct_garbage: pd.Series,
+    logit_pct_garbage_sd: pd.Series,
+    envelope_ub: float,
+) -> pd.Series:
+    """VR effective binomial sample size."""
+    n = completeness * population
+    a = mx * (envelope_ub - cause_fraction * mx)
+    b = cause_fraction * (
+        mx_sd**2 + pct_garbage**2 * logit_pct_garbage_sd**2 * (mx**2 + mx_sd**2)
+    )
+    numerator = n * a
+    denominator = a + (n - 1.0).clip(lower=0.0) * b
+    return numerator / denominator
+
+
+def va_effective_sample_size(
+    sample_size: pd.Series,
+    envelope: pd.Series,
+    mx: pd.Series,
+    cause_fraction: pd.Series,
+    mx_sd: pd.Series,
+    pct_garbage: pd.Series,
+    logit_pct_garbage_sd: pd.Series,
+    envelope_ub: float,
+) -> pd.Series:
+    """VA effective binomial sample size."""
+    # A cause's VA count can't exceed the all-cause envelope; capping there also keeps the
+    # effective all-cause population env_va / mx <= n_pop, no separate population cap is needed.
+    env_va = sample_size.clip(upper=envelope)
+    pop_va = env_va / mx
+    # All-cause variance on the effective population implied by the VA sample.
+    var_ra_va = (
+        mx * (envelope_ub - mx) / pop_va
+        + (pop_va - 1.0).clip(lower=0.0) / pop_va * mx_sd**2
+    )
+    v = var_ra_va + mx**2
+    a = (envelope_ub - cause_fraction) * v
+    b = (
+        (env_va - 1.0).clip(lower=0.0)
+        * cause_fraction
+        * pct_garbage**2
+        * logit_pct_garbage_sd**2
+        * v
+    )
+    c = env_va * cause_fraction * var_ra_va
+    numerator = env_va * mx * (envelope_ub - cause_fraction * mx)
+    denominator = a + b + c
+    return numerator / denominator
+
+
+def effective_sample_size(
+    is_vr: pd.Series,
+    completeness: pd.Series,
+    sample_size: pd.Series,
+    population: pd.Series,
+    envelope: pd.Series,
+    envelope_sd: pd.Series,
+    cause_fraction: pd.Series,
+    pct_garbage: pd.Series,
+    logit_pct_garbage_mad: pd.Series,
+    envelope_ub: float,
+) -> pd.Series:
+    """Per-row effective binomial sample size: VR where ``is_vr`` else VA."""
+    # Compute the all-cause death rate and convert SD from death-count to rate scale
+    mx = envelope / population
+    mx_sd = envelope_sd / population
+    # Derive the redistribution SD from the logit-pct-garbage MAD (source is a MAD)
+    logit_pct_garbage_sd = _MAD_TO_SD * logit_pct_garbage_mad
+
+    weights = pd.Series(index=is_vr.index, dtype="float64")
+    weights[is_vr] = vr_effective_sample_size(
+        completeness=completeness[is_vr],
+        population=population[is_vr],
+        mx=mx[is_vr],
+        cause_fraction=cause_fraction[is_vr],
+        mx_sd=mx_sd[is_vr],
+        pct_garbage=pct_garbage[is_vr],
+        logit_pct_garbage_sd=logit_pct_garbage_sd[is_vr],
+        envelope_ub=envelope_ub,
+    )
+    weights[~is_vr] = va_effective_sample_size(
+        sample_size=sample_size[~is_vr],
+        envelope=envelope[~is_vr],
+        mx=mx[~is_vr],
+        cause_fraction=cause_fraction[~is_vr],
+        mx_sd=mx_sd[~is_vr],
+        pct_garbage=pct_garbage[~is_vr],
+        logit_pct_garbage_sd=logit_pct_garbage_sd[~is_vr],
+        envelope_ub=envelope_ub,
+    )
+    return weights

--- a/src/msca/modeling/effective_sample_size.py
+++ b/src/msca/modeling/effective_sample_size.py
@@ -1,12 +1,13 @@
 """Effective binomial sample size of a cause-specific death rate."""
 
+import numpy as np
 import pandas as pd
 
 # Normal-consistency factor from median absolute deviation to SD.
 _MAD_TO_SD = 1.4826
 
 
-def vr_effective_sample_size(
+def _vr_effective_sample_size(
     cause_fraction: pd.Series,
     all_cause_death_rate: pd.Series,
     all_cause_death_rate_sd: pd.Series,
@@ -32,7 +33,7 @@ def vr_effective_sample_size(
     return numerator / denominator
 
 
-def nonvr_effective_sample_size(
+def _non_vr_effective_sample_size(
     cause_fraction: pd.Series,
     sample_size: pd.Series,
     all_cause_death_rate: pd.Series,
@@ -73,44 +74,113 @@ def nonvr_effective_sample_size(
     return numerator / denominator
 
 
+def _validate_data(
+    data: pd.DataFrame,
+    is_vr: str,
+    cause_fraction: str,
+    sample_size: str,
+    population: str,
+    envelope: str,
+    envelope_sd: str,
+    completeness: str,
+    pct_garbage: str,
+    logit_pct_garbage_mad: str,
+    envelope_ub: float,
+) -> None:
+    nona_columns = [
+        is_vr,
+        cause_fraction,
+        sample_size,
+        population,
+        envelope,
+        envelope_sd,
+        pct_garbage,
+        logit_pct_garbage_mad,
+    ]
+    na_cols = [col for col in nona_columns if data[col].isna().any()]
+    if len(na_cols) > 0:
+        raise ValueError(f"Columns contain missing values: {na_cols}")
+
+    if not pd.api.types.is_bool_dtype(data[is_vr]):
+        raise ValueError(f"{is_vr} must be in boolean type")
+
+    if data.loc[data[is_vr].to_numpy(), completeness].isna().any():
+        raise ValueError(f"{completeness} must not be missing for VR rows")
+
+    for col in (cause_fraction, completeness, pct_garbage):
+        if not data[col].between(0.0, 1.0).all():
+            raise ValueError(f"{col} must be in [0, 1]")
+
+    for col in (sample_size, population, envelope, envelope_sd):
+        if (data[col] <= 0).any():
+            raise ValueError(f"{col} must be positive")
+
+    if (data[envelope] / data[population] > envelope_ub).any():
+        raise ValueError(
+            f"{envelope} / {population} must be less than or equal to envelope_ub ({envelope_ub})"
+        )
+
+
 def effective_sample_size(
-    is_vr: pd.Series,
-    cause_fraction: pd.Series,
-    sample_size: pd.Series,
-    population: pd.Series,
-    envelope: pd.Series,
-    envelope_sd: pd.Series,
-    completeness: pd.Series,
-    pct_garbage: pd.Series,
-    logit_pct_garbage_mad: pd.Series,
+    data: pd.DataFrame,
+    is_vr: str,
+    cause_fraction: str,
+    sample_size: str,
+    population: str,
+    envelope: str,
+    envelope_sd: str,
+    completeness: str,
+    pct_garbage: str,
+    logit_pct_garbage_mad: str,
     envelope_ub: float,
 ) -> pd.Series:
     """Per-row effective binomial sample size: VR where ``is_vr`` else VA."""
-    # Compute the all-cause death rate and convert SD from death-count to rate scale
-    all_cause_death_rate = envelope / population
-    all_cause_death_rate_sd = envelope_sd / population
-    # Derive the redistribution SD from the logit-pct-garbage MAD (source is a MAD)
-    logit_pct_garbage_sd = _MAD_TO_SD * logit_pct_garbage_mad
+    _validate_data(
+        data,
+        is_vr,
+        cause_fraction,
+        sample_size,
+        population,
+        envelope,
+        envelope_sd,
+        completeness,
+        pct_garbage,
+        logit_pct_garbage_mad,
+        envelope_ub,
+    )
 
-    weights = pd.Series(index=is_vr.index, dtype="float64")
-    weights[is_vr] = vr_effective_sample_size(
-        cause_fraction=cause_fraction[is_vr],
-        all_cause_death_rate=all_cause_death_rate[is_vr],
-        all_cause_death_rate_sd=all_cause_death_rate_sd[is_vr],
-        population=population[is_vr],
-        completeness=completeness[is_vr],
-        pct_garbage=pct_garbage[is_vr],
-        logit_pct_garbage_sd=logit_pct_garbage_sd[is_vr],
+    # Compute the all-cause death rate and convert SD from death-count to rate scale
+    all_cause_death_rate = data[envelope] / data[population]
+    all_cause_death_rate_sd = data[envelope_sd] / data[population]
+    # Derive the redistribution SD from the logit-pct-garbage MAD (source is a MAD)
+    logit_pct_garbage_sd = _MAD_TO_SD * data[logit_pct_garbage_mad]
+
+    weights = pd.Series(index=data.index, dtype="float64")
+    vr_mask = data[is_vr].to_numpy()
+    weights[vr_mask] = _vr_effective_sample_size(
+        cause_fraction=data.loc[vr_mask, cause_fraction],
+        all_cause_death_rate=all_cause_death_rate[vr_mask],
+        all_cause_death_rate_sd=all_cause_death_rate_sd[vr_mask],
+        population=data.loc[vr_mask, population],
+        completeness=data.loc[vr_mask, completeness],
+        pct_garbage=data.loc[vr_mask, pct_garbage],
+        logit_pct_garbage_sd=logit_pct_garbage_sd[vr_mask],
         envelope_ub=envelope_ub,
     )
-    weights[~is_vr] = nonvr_effective_sample_size(
-        cause_fraction=cause_fraction[~is_vr],
-        sample_size=sample_size[~is_vr],
-        all_cause_death_rate=all_cause_death_rate[~is_vr],
-        all_cause_death_rate_sd=all_cause_death_rate_sd[~is_vr],
-        envelope=envelope[~is_vr],
-        pct_garbage=pct_garbage[~is_vr],
-        logit_pct_garbage_sd=logit_pct_garbage_sd[~is_vr],
+    weights[~vr_mask] = _non_vr_effective_sample_size(
+        cause_fraction=data.loc[~vr_mask, cause_fraction],
+        sample_size=data.loc[~vr_mask, sample_size],
+        all_cause_death_rate=all_cause_death_rate[~vr_mask],
+        all_cause_death_rate_sd=all_cause_death_rate_sd[~vr_mask],
+        envelope=data.loc[~vr_mask, envelope],
+        pct_garbage=data.loc[~vr_mask, pct_garbage],
+        logit_pct_garbage_sd=logit_pct_garbage_sd[~vr_mask],
         envelope_ub=envelope_ub,
     )
+
+    not_valid = ~np.isfinite(weights) | (weights < 0)
+    if not_valid.any():
+        raise ValueError(
+            f"Invalid effective sample size for rows: {list(data.index[not_valid])}"
+        )
     return weights

--- a/tests/modeling/test_effective_sample_size.py
+++ b/tests/modeling/test_effective_sample_size.py
@@ -15,6 +15,12 @@ from msca.modeling import effective_sample_size
 
 ALL_CAUSE_DEATH_RATE_UB = 4.0
 
+# The reference implementation took a median absolute deviation and scaled
+# it internally; this function takes the standard deviation directly. The
+# fixtures pre-apply the factor so REFERENCE_WEIGHTS stays comparable to
+# the values onemod_cod v1.19 produced from the same underlying data.
+MAD_TO_SD = 1.4826
+
 # Maps each parameter of effective_sample_size to a column of `data`.
 COLUMNS = {
     "is_vr": "is_vr",
@@ -25,7 +31,7 @@ COLUMNS = {
     "envelope_sd": "envelope_sd",
     "completeness": "completeness",
     "pct_garbage": "pct_garbage",
-    "logit_pct_garbage_mad": "logit_pct_garbage_mad",
+    "logit_pct_garbage_sd": "logit_pct_garbage_sd",
 }
 
 REFERENCE_WEIGHTS = [
@@ -46,7 +52,7 @@ REQUIRED_COLUMNS = [
     "envelope",
     "envelope_sd",
     "pct_garbage",
-    "logit_pct_garbage_mad",
+    "logit_pct_garbage_sd",
 ]
 
 POSITIVE_COLUMNS = ["sample_size", "population", "envelope", "envelope_sd"]
@@ -65,7 +71,9 @@ def data():
             "envelope_sd": [20.0, 80.0, 6.0, 20.0, 80.0, 6.0],
             "completeness": [0.95, 0.80, 0.60, 0.90, 0.90, 0.90],
             "pct_garbage": [0.10, 0.25, 0.05, 0.10, 0.25, 0.05],
-            "logit_pct_garbage_mad": [0.5, 0.3, 0.8, 0.5, 0.3, 0.8],
+            "logit_pct_garbage_sd": [
+                MAD_TO_SD * mad for mad in (0.5, 0.3, 0.8, 0.5, 0.3, 0.8)
+            ],
         }
     )
 
@@ -174,7 +182,7 @@ def sub_unit_data():
             "envelope_sd": [0.1, 0.1],
             "completeness": [0.5, 0.5],
             "pct_garbage": [0.1, 0.1],
-            "logit_pct_garbage_mad": [0.5, 0.5],
+            "logit_pct_garbage_sd": [MAD_TO_SD * 0.5, MAD_TO_SD * 0.5],
         }
     )
 

--- a/tests/modeling/test_effective_sample_size.py
+++ b/tests/modeling/test_effective_sample_size.py
@@ -13,7 +13,7 @@ import pytest
 
 from msca.modeling import effective_sample_size
 
-ENVELOPE_UB = 4.0
+ALL_CAUSE_DEATH_RATE_UB = 4.0
 
 # Maps each parameter of effective_sample_size to a column of `data`.
 COLUMNS = {
@@ -70,10 +70,12 @@ def data():
     )
 
 
-def ess(data, envelope_ub=ENVELOPE_UB, **columns):
+def ess(data, all_cause_death_rate_ub=ALL_CAUSE_DEATH_RATE_UB, **columns):
     """Call effective_sample_size with the default column mapping."""
     return effective_sample_size(
-        data, envelope_ub=envelope_ub, **{**COLUMNS, **columns}
+        data,
+        all_cause_death_rate_ub=all_cause_death_rate_ub,
+        **{**COLUMNS, **columns},
     )
 
 
@@ -279,9 +281,11 @@ def test_non_positive_raises(data, column, value):
         ess(data)
 
 
-def test_death_rate_above_envelope_ub_raises(data):
-    data.loc[0, "envelope"] = data.loc[0, "population"] * (ENVELOPE_UB + 1.0)
-    with pytest.raises(ValueError, match="envelope_ub"):
+def test_death_rate_above_all_cause_death_rate_ub_raises(data):
+    data.loc[0, "envelope"] = data.loc[0, "population"] * (
+        ALL_CAUSE_DEATH_RATE_UB + 1.0
+    )
+    with pytest.raises(AssertionError, match="all_cause_death_rate_ub"):
         ess(data)
 
 

--- a/tests/modeling/test_effective_sample_size.py
+++ b/tests/modeling/test_effective_sample_size.py
@@ -1,0 +1,292 @@
+"""Tests for :func:`msca.modeling.effective_sample_size`.
+
+The reference values in :data:`REFERENCE_WEIGHTS` were produced by the
+implementation this module replaced, ``onemod_cod`` v1.19
+``utils/effective_sample_size.py``. They exist to catch any change in
+the numbers the function returns, so update them only when a change in
+results is intended.
+"""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from msca.modeling import effective_sample_size
+
+ENVELOPE_UB = 4.0
+
+# Maps each parameter of effective_sample_size to a column of `data`.
+COLUMNS = {
+    "is_vr": "is_vr",
+    "cause_fraction": "cause_fraction",
+    "sample_size": "sample_size",
+    "population": "population",
+    "envelope": "envelope",
+    "envelope_sd": "envelope_sd",
+    "completeness": "completeness",
+    "pct_garbage": "pct_garbage",
+    "logit_pct_garbage_mad": "logit_pct_garbage_mad",
+}
+
+REFERENCE_WEIGHTS = [
+    91154.86140893624,
+    75497.28440306992,
+    29965.463205731998,
+    91610.23310940086,
+    78294.77130696688,
+    48187.04146872915,
+]
+
+# Columns that must never contain missing values, unlike completeness.
+REQUIRED_COLUMNS = [
+    "is_vr",
+    "cause_fraction",
+    "sample_size",
+    "population",
+    "envelope",
+    "envelope_sd",
+    "pct_garbage",
+    "logit_pct_garbage_mad",
+]
+
+POSITIVE_COLUMNS = ["sample_size", "population", "envelope", "envelope_sd"]
+
+
+@pytest.fixture
+def data():
+    """Three vital registration rows followed by three non-VR rows."""
+    return pd.DataFrame(
+        {
+            "is_vr": [True, True, True, False, False, False],
+            "cause_fraction": [0.05, 0.20, 0.01, 0.05, 0.20, 0.01],
+            "sample_size": [1000.0, 5000.0, 200.0, 800.0, 4000.0, 150.0],
+            "population": [1e5, 2e5, 5e4, 1e5, 2e5, 5e4],
+            "envelope": [500.0, 2000.0, 150.0, 500.0, 2000.0, 150.0],
+            "envelope_sd": [20.0, 80.0, 6.0, 20.0, 80.0, 6.0],
+            "completeness": [0.95, 0.80, 0.60, 0.90, 0.90, 0.90],
+            "pct_garbage": [0.10, 0.25, 0.05, 0.10, 0.25, 0.05],
+            "logit_pct_garbage_mad": [0.5, 0.3, 0.8, 0.5, 0.3, 0.8],
+        }
+    )
+
+
+def ess(data, envelope_ub=ENVELOPE_UB, **columns):
+    """Call effective_sample_size with the default column mapping."""
+    return effective_sample_size(
+        data, envelope_ub=envelope_ub, **{**COLUMNS, **columns}
+    )
+
+
+def test_reference_values(data):
+    result = ess(data)
+    assert isinstance(result, pd.Series)
+    assert result.dtype == "float64"
+    np.testing.assert_allclose(result.to_numpy(), REFERENCE_WEIGHTS, rtol=1e-12)
+
+
+def test_column_names_are_honored(data):
+    renamed = data.rename(columns={"cause_fraction": "cf", "population": "pop"})
+    result = ess(renamed, cause_fraction="cf", population="pop")
+    np.testing.assert_allclose(result.to_numpy(), REFERENCE_WEIGHTS, rtol=1e-12)
+
+
+def test_extra_columns_are_ignored(data):
+    data["location_id"] = [101, 102, 103, 104, 105, 106]
+    data["unused"] = np.nan
+    np.testing.assert_allclose(
+        ess(data).to_numpy(), REFERENCE_WEIGHTS, rtol=1e-12
+    )
+
+
+@pytest.mark.parametrize(
+    "index",
+    [
+        pd.RangeIndex(6),
+        pd.Index([0, 0, 1, 1, 2, 2]),  # duplicate labels
+        pd.Index(list("abcdef")),
+        pd.Index([50, 40, 30, 20, 10, 0]),  # descending
+    ],
+    ids=["range", "duplicate", "string", "descending"],
+)
+def test_index_is_preserved(data, index):
+    data.index = index
+    result = ess(data)
+    assert result.index.equals(index)
+    np.testing.assert_allclose(result.to_numpy(), REFERENCE_WEIGHTS, rtol=1e-12)
+
+
+def test_rows_are_independent(data):
+    reversed_result = ess(data.iloc[::-1])
+    np.testing.assert_allclose(
+        reversed_result.to_numpy(), REFERENCE_WEIGHTS[::-1], rtol=1e-12
+    )
+
+
+@pytest.mark.parametrize("is_vr", [True, False], ids=["all_vr", "all_non_vr"])
+def test_row_type_dispatch(data, is_vr):
+    """Each row is computed by the form its own is_vr flag selects."""
+    uniform = ess(data.assign(is_vr=is_vr))
+    mixed = ess(data)
+    rows = data["is_vr"].to_numpy() == is_vr
+    np.testing.assert_allclose(
+        mixed[rows].to_numpy(), uniform[rows].to_numpy(), rtol=1e-12
+    )
+
+
+def test_zero_completeness_gives_zero_weight(data):
+    """A VR source that registers nothing carries no information."""
+    data.loc[0, "completeness"] = 0.0
+    result = ess(data)
+    assert result.iloc[0] == 0.0
+    np.testing.assert_allclose(
+        result.to_numpy()[1:], REFERENCE_WEIGHTS[1:], rtol=1e-12
+    )
+
+
+def test_no_extra_uncertainty_recovers_nominal_sample_size(data):
+    """Without envelope or redistribution error, a VR weight is the
+    registered death count."""
+    data["pct_garbage"] = 0.0
+    data["envelope_sd"] = 1e-12
+    result = ess(data)
+    is_vr = data["is_vr"].to_numpy()
+    nominal = (data["completeness"] * data["population"])[is_vr]
+    np.testing.assert_allclose(
+        result[is_vr].to_numpy(), nominal.to_numpy(), rtol=1e-9
+    )
+
+
+SUB_UNIT_WEIGHTS = [0.25, 0.0491183879093199]
+
+
+@pytest.fixture
+def sub_unit_data():
+    """One row of each type with fewer than one expected death."""
+    return pd.DataFrame(
+        {
+            "is_vr": [True, False],
+            "cause_fraction": [0.05, 0.05],
+            "sample_size": [0.5, 0.5],
+            "population": [0.5, 0.5],
+            "envelope": [1.0, 1.0],
+            "envelope_sd": [0.1, 0.1],
+            "completeness": [0.5, 0.5],
+            "pct_garbage": [0.1, 0.1],
+            "logit_pct_garbage_mad": [0.5, 0.5],
+        }
+    )
+
+
+def test_sub_unit_sample_size_is_clipped(sub_unit_data):
+    """Below one expected death the variance inflation terms are clipped
+    away instead of going negative, so the VR weight collapses to the
+    registered death count."""
+    result = ess(sub_unit_data)
+    nominal = (
+        sub_unit_data["completeness"] * sub_unit_data["population"]
+    ).iloc[0]
+    assert result.iloc[0] == nominal
+    np.testing.assert_allclose(result.to_numpy(), SUB_UNIT_WEIGHTS, rtol=1e-12)
+    assert (result > 0).all()
+
+
+def test_vr_weight_never_exceeds_nominal_sample_size(data):
+    result = ess(data)
+    is_vr = data["is_vr"].to_numpy()
+    nominal = (data["completeness"] * data["population"])[is_vr]
+    assert (result[is_vr] <= nominal).all()
+
+
+def test_weight_increases_with_population(data):
+    """More people at risk means more information, all else equal."""
+    larger = ess(data.assign(population=data["population"] * 2.0))
+    assert (larger > ess(data)).all()
+
+
+def test_empty_data():
+    empty = pd.DataFrame(
+        {
+            column: pd.Series(dtype="bool" if column == "is_vr" else "float64")
+            for column in COLUMNS.values()
+        }
+    )
+    result = ess(empty)
+    assert len(result) == 0
+    assert result.dtype == "float64"
+
+
+def test_input_is_not_modified(data):
+    original = data.copy()
+    ess(data)
+    pd.testing.assert_frame_equal(data, original)
+
+
+@pytest.mark.parametrize("column", REQUIRED_COLUMNS)
+def test_missing_values_raise(data, column):
+    data[column] = data[column].astype("float64")
+    data.loc[0, column] = np.nan
+    with pytest.raises(ValueError, match="Columns contain missing values"):
+        ess(data)
+
+
+@pytest.mark.parametrize(
+    "is_vr",
+    [[1, 1, 1, 0, 0, 0], [1.0, 1.0, 1.0, 0.0, 0.0, 0.0], list("aaabbb")],
+    ids=["int", "float", "str"],
+)
+def test_is_vr_must_be_boolean(data, is_vr):
+    data["is_vr"] = is_vr
+    with pytest.raises(ValueError, match="must be in boolean type"):
+        ess(data)
+
+
+def test_nullable_boolean_is_accepted(data):
+    data["is_vr"] = data["is_vr"].astype("boolean")
+    np.testing.assert_allclose(
+        ess(data).to_numpy(), REFERENCE_WEIGHTS, rtol=1e-12
+    )
+
+
+@pytest.mark.parametrize("column", ["cause_fraction", "pct_garbage"])
+@pytest.mark.parametrize("value", [-0.1, 1.1])
+def test_proportion_out_of_range_raises(data, column, value):
+    data.loc[0, column] = value
+    with pytest.raises(ValueError, match="must be in"):
+        ess(data)
+
+
+@pytest.mark.parametrize("value", [-0.1, 1.1, np.nan])
+def test_completeness_is_validated_on_vr_rows(data, value):
+    data.loc[0, "completeness"] = value
+    with pytest.raises(ValueError, match="completeness must be in"):
+        ess(data)
+
+
+@pytest.mark.parametrize("value", [-0.1, 1.1, np.nan])
+def test_completeness_is_ignored_on_non_vr_rows(data, value):
+    """The non-VR form never reads completeness."""
+    data.loc[~data["is_vr"], "completeness"] = value
+    np.testing.assert_allclose(
+        ess(data).to_numpy(), REFERENCE_WEIGHTS, rtol=1e-12
+    )
+
+
+@pytest.mark.parametrize("column", POSITIVE_COLUMNS)
+@pytest.mark.parametrize("value", [0.0, -1.0])
+def test_non_positive_raises(data, column, value):
+    data.loc[0, column] = value
+    with pytest.raises(ValueError, match="must be positive"):
+        ess(data)
+
+
+def test_death_rate_above_envelope_ub_raises(data):
+    data.loc[0, "envelope"] = data.loc[0, "population"] * (ENVELOPE_UB + 1.0)
+    with pytest.raises(ValueError, match="envelope_ub"):
+        ess(data)
+
+
+def test_non_finite_weight_raises(data):
+    """Infinite inputs pass the range checks, so the output is guarded."""
+    data.loc[0, "population"] = np.inf
+    with pytest.raises(ValueError, match="Invalid effective sample size"):
+        ess(data)


### PR DESCRIPTION
## Summary

Effective sample size is currently implemented twice, in `onemod_cod` and
`onemod_cov`, so any fix has to land in both places and the CoD team can't
compute ESS without installing a pipeline package. This adds it to `msca` as
`msca.modeling.effective_sample_size`, ported from `onemod_cod` v1.19 with the
formulas unchanged.

## What changed

- **New** `src/msca/modeling/effective_sample_size.py` — public
  `effective_sample_size`, with the VR and non-VR forms and validation as
  private helpers.
- **API**: takes a DataFrame plus column names, matching
  `msca.metrics.Metric.eval`, rather than ten separate Series.
- **Validation**: rejects missing values, non-boolean `is_vr`, proportions
  outside `[0, 1]`, non-positive `sample_size`/`population`/`envelope`/
  `envelope_sd`, and `envelope / population` above `envelope_ub`.
  `completeness` is checked on VR rows only, since only the VR form reads it.
  A final guard rejects non-finite or negative results, which catches
  infinite inputs that pass every range check.
- **New** `tests/modeling/test_effective_sample_size.py` — 49 tests.
- **New** `docs/api_reference/msca.modeling.rst`.
- **Modified** `pyproject.toml` — version `0.4.2` → `0.5.0`.

Refs [MSCA-794](https://jira.ihme.washington.edu/browse/MSCA-794)